### PR TITLE
Update documentation of ballistic models

### DIFF
--- a/casex/ballistic_descent_models.py
+++ b/casex/ballistic_descent_models.py
@@ -112,7 +112,7 @@ class BallisticDescent2ndOrderDragApproximation:
         velocity_impact: float
             [m/s] The impact velocity.
         angle_impact : float
-            [deg] The impact angle (relative to horizontal).
+            [rad] The impact angle (relative to horizontal).
         time_impact: float
             [s] Time from event to impact.
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='casex',
-    version='1.0.6',
+    version='1.0.7',
     description='Casualty expectation toolbox',
     long_description=long_description,
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
This is a small change to correct the units declared in the documentation of `compute_ballistic_distance`.

The usual units for degrees in this package are angle so it would make sense to instead correct this behaviour in the source directly but this may cause existing scripts to break. If you would like to take this route on top of updating the documentation please let me know.